### PR TITLE
Calculate the number of bytes in the file instead of a fixed number

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,2 +1,2 @@
-injected_s = 3556020
+injected_s = len(open("fsoc.gif", "rb").read())
 test_folder = "important_docs/"


### PR DESCRIPTION
- [x] Calculate the number of bytes in the [__fsoc.gif__](https://github.com/ramirak/Havoc-Ransomware/blob/master/crypt.py) file instead of a fixed number

This allows you to understand exactly what is happening. Also, the user can enter his own file instead of the fsoc.gif file (no need for recalculations).

- This change also requires approval of the Pull-requests **resore.py** file